### PR TITLE
Add Claude Code configuration

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://raw.githubusercontent.com/anthropics/claude-code/main/.claude/settings.schema.json",
+  "_comment": "Claude Code settings for Python backend projects",
+  "env": {
+    "PYTHONDONTWRITEBYTECODE": "1"
+  },
+  "hooks": {
+    "PreCommit": [
+      {
+        "command": "ruff check ."
+      },
+      {
+        "command": "ruff format --check ."
+      }
+    ]
+  },
+  "permissions": {
+    "allow": [
+      "python",
+      "pip install",
+      "pip list",
+      "pytest",
+      "ruff check",
+      "ruff format",
+      "uvicorn"
+    ],
+    "deny": [
+      "pip install --break-system-packages",
+      "rm -rf /",
+      "python -c \"import os; os.system"
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,48 @@
+# Instructions — Python Backend
+
+## Context
+Python backend.
+
+## Stack
+- Language: Python 3.11+
+- Framework: FastAPI (adapt: Django, Flask, etc.)
+- Database: PostgreSQL (adapt to your project)
+- ORM: SQLAlchemy / Django ORM
+- Tests: pytest
+- Linting: ruff
+- Type checking: mypy
+
+## Commands
+- `uvicorn app.main:app --reload` — Start in development
+- `pytest` — Run the tests
+- `ruff check .` — Check linting
+- `mypy .` — Check types
+
+## Conventions
+- Type hints on all public functions
+- Google-style docstrings on public functions/classes
+- Virtual env required (venv or poetry)
+- Requirements pinned in `requirements.txt` or `pyproject.toml`
+- Pydantic for data validation
+- Async when relevant (I/O bound)
+- No `print()` — use `logging`
+
+## Security
+- Never hardcode secrets — use environment variables
+- Validate inputs with Pydantic
+- Parameterized queries (SQLAlchemy, Django ORM — never SQL f-strings)
+- Scan dependencies regularly (pip-audit)
+- Log errors, never sensitive data
+
+## Structure
+```
+src/
+├── api/           # Routes/endpoints
+├── models/        # Data models
+├── services/      # Business logic
+├── repositories/  # Data access
+└── utils/         # Utilities
+tests/
+├── unit/
+└── integration/
+```


### PR DESCRIPTION
## Summary

Added Claude Code configuration based on the `python-backend` template from [claude-central](https://github.com/stevenaubertin/claude-central).

### Files added
- `CLAUDE.md` — Project-specific instructions
- `.claude/settings.json` — Permissions and hooks
- `.claude/rules/` — Code rules

### Source
Template: `python-backend` from [claude-central](https://github.com/stevenaubertin/claude-central)

---
🤖 Automatically generated by claude-central/deploy-to-repos.sh